### PR TITLE
Fix hierarchy cleanup error when using type_caster

### DIFF
--- a/lib/closure_tree/hierarchy_maintenance.rb
+++ b/lib/closure_tree/hierarchy_maintenance.rb
@@ -123,7 +123,7 @@ module ClosureTree
 
         [:descendant_id, :ancestor_id].each do |foreign_key|
           alias_name = foreign_key.to_s.split('_').first + "s"
-          alias_table = Arel::Table.new(table_name).alias(alias_name)
+          alias_table = Arel::Table.new(table_name, type_caster: type_caster).alias(alias_name)
           arel_join = hierarchy_table.join(alias_table, Arel::Nodes::OuterJoin)
                                      .on(alias_table[primary_key].eq(hierarchy_table[foreign_key]))
                                      .join_sources


### PR DESCRIPTION
This commit fixes an issue where a database proxy tries
to access the type_caster on the aliased arel table. Since
this is just an alias table of the current model, it makes
sense to use the current model's type_caster for the alias.